### PR TITLE
修改证书获取不明确问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Mac 下
 - Android设置代理步骤：`设置 - WLAN - 长按选中网络 - 修改网络 - 高级 - 代理设置 - 手动`  
 - iOS设置代理步骤：`设置 - 无线局域网 - 选中网络 - HTTP代理手动`  
 >  
-第四步：手机安装证书。**注：手机必须先设置完代理后再通过(非微信)手机浏览器访问`http://s.xxx`[`(地址二维码)`](demo/img/QRCodeForCert.png)安装证书**（手机首次调试需要安装证书，已安装了证书的手机无需重复安装)。[问题：iOS `10.3.1`以上版本证书安装问题](https://github.com/wuchangming/spy-debugger/issues/42)
+第四步：手机安装证书。**注：手机必须先设置完代理后再通过(非微信)手机浏览器访问`http://s.xxx`[`(地址二维码)`](demo/img/QRCodeForCert.png)安装证书**（证书默认生成在：~/node-mitmproxy目录下，手机首次调试需要安装证书，已安装了证书的手机无需重复安装)。[问题：iOS `10.3.1`以上版本证书安装问题](https://github.com/wuchangming/spy-debugger/issues/42)
 >  
 第五步：用手机浏览器访问你要调试的页面即可。
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Mac 下
 - Android设置代理步骤：`设置 - WLAN - 长按选中网络 - 修改网络 - 高级 - 代理设置 - 手动`  
 - iOS设置代理步骤：`设置 - 无线局域网 - 选中网络 - HTTP代理手动`  
 >  
-第四步：手机安装证书。**注：手机必须先设置完代理后再通过(非微信)手机浏览器访问`http://s.xxx`[`(地址二维码)`](demo/img/QRCodeForCert.png)安装证书**（证书默认生成在：~/node-mitmproxy目录下，手机首次调试需要安装证书，已安装了证书的手机无需重复安装)。[问题：iOS `10.3.1`以上版本证书安装问题](https://github.com/wuchangming/spy-debugger/issues/42)
+第四步：手机安装证书。**注：手机必须先设置完代理后再通过(非微信)手机浏览器访问`http://s.xxx`安装证书**（证书默认生成在：~/node-mitmproxy目录下，手机首次调试需要安装证书，已安装了证书的手机无需重复安装)。[问题：iOS `10.3.1`以上版本证书安装问题](https://github.com/wuchangming/spy-debugger/issues/42)
 >  
 第五步：用手机浏览器访问你要调试的页面即可。
 


### PR DESCRIPTION
原二维码扫描后跳转的地址不存在，实际证书可从用户目录下获取